### PR TITLE
Require 2.361.4 as minimum Jenkins version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,12 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.580.1</version>
+        <version>4.51</version>
+        <relativePath />
     </parent>
 
     <properties>
+        <jenkins.version>2.346.3</jenkins.version>
         <jenkins.build.number>local</jenkins.build.number>
     </properties>
 
@@ -49,6 +51,18 @@
         </license>
     </licenses>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.346.x</artifactId>
+                <version>1763.v092b_8980a_f5e</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -58,7 +72,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.3.19</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -75,7 +88,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.9</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <properties>
-        <jenkins.version>2.346.3</jenkins.version>
+        <jenkins.version>2.361.4</jenkins.version>
         <jenkins.build.number>local</jenkins.build.number>
     </properties>
 
@@ -55,7 +55,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.346.x</artifactId>
+                <artifactId>bom-2.361.x</artifactId>
                 <version>1763.v092b_8980a_f5e</version>
                 <scope>import</scope>
                 <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -107,15 +107,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
-                    <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.jenkins-ci.tools</groupId>
                     <artifactId>maven-hpi-plugin</artifactId>
                     <configuration>
@@ -127,14 +118,6 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
                         <additionalparam>-Xdoclint:none</additionalparam>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.17</version>
-                    <configuration>
-                        <skipTests>false</skipTests>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -161,11 +144,6 @@
                             </configuration>
                         </execution>
                     </executions>
-                </plugin>
-                <plugin><!-- Can be removed again when required core is updated to 1.428+ -->
-                    <groupId>com.cloudbees</groupId>
-                    <artifactId>maven-license-plugin</artifactId>
-                    <version>1.3</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.51</version>
+        <version>4.53</version>
         <relativePath />
     </parent>
 

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<FindBugsFilter>
+  <!--
+    Exclusions in this section have been triaged and determined to be
+    false positives.
+  -->
+
+  <!--
+    Here lies technical debt. Exclusions in this section have not yet
+    been triaged. When working on this section, pick an exclusion to
+    triage, then:
+
+    - Add a @SuppressFBWarnings(value = "[...]", justification = "[...]")
+      annotation if it is a false positive.  Indicate the reason why
+      it is a false positive, then remove the exclusion from this
+      section.
+
+    - If it is not a false positive, fix the bug, then remove the
+      exclusion from this section.
+   -->
+  <Match>
+    <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD"/>
+    <Class name="hudson.plugins.blazemeter.BlazeMeterPerformanceBuilderDescriptor"/>
+    <Field name="descriptor"/>
+  </Match>
+  <Match>
+    <Bug pattern="SE_COMPARATOR_SHOULD_BE_SERIALIZABLE"/>
+    <Class name="hudson.plugins.blazemeter.AbstractTestComparator"/>
+  </Match>
+  <Match>
+    <Bug pattern="MS_SHOULD_BE_FINAL"/>
+    <Class name="hudson.plugins.blazemeter.BlazemeterCredentialsBAImpl"/>
+    <Field name="EMPTY"/>
+  </Match>
+  <Match>
+    <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+    <Class name="hudson.plugins.blazemeter.BlazemeterCredentialsBAImpl$DescriptorImpl"/>
+    <Method name="getProjectLevelCredentialsStatus"/>
+  </Match>
+  <Match>
+    <Bug pattern="SE_BAD_FIELD"/>
+    <Class name="hudson.plugins.blazemeter.BzmBuild"/>
+    <Or>
+      <Field name="build"/>
+      <Field name="master"/>
+    </Or>
+  </Match>
+  <Match>
+    <Bug pattern="MS_SHOULD_BE_FINAL"/>
+    <Class name="hudson.plugins.blazemeter.utils.JenkinsBlazeMeterUtils"/>
+    <Field name="JENKINS_PLUGIN_INFO"/>
+  </Match>
+  <Match>
+    <Bug pattern="URF_UNREAD_FIELD"/>
+    <Class name="hudson.plugins.blazemeter.PerformanceBuilderDSLContext"/>
+    <Field name="workspaceId"/>
+  </Match>
+  <Match>
+    <Bug pattern="DLS_DEAD_LOCAL_STORE"/>
+    <Class name="hudson.plugins.blazemeter.PerformanceBuilderDSLExtension"/>
+    <Method name="blazeMeterTest"/>
+  </Match>
+  <Match>
+    <Bug pattern="NP_NULL_ON_SOME_PATH_EXCEPTION"/>
+    <Class name="hudson.plugins.blazemeter.utils.JenkinsTestListFlow"/>
+    <Method name="getWorkspacesForUser"/>
+  </Match>
+  <Match>
+    <Bug pattern="STCAL_INVOKE_ON_STATIC_DATE_FORMAT_INSTANCE"/>
+    <Class name="hudson.plugins.blazemeter.utils.notifier.BzmJobNotifier"/>
+    <Method name="formatMessage"/>
+  </Match>
+  <Match>
+    <Bug pattern="OBL_UNSATISFIED_OBLIGATION"/>
+    <Class name="hudson.plugins.blazemeter.utils.Utils"/>
+    <Method name="version"/>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
See the ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/) for the guidance that inspires this type of change.  This change requires the plugin to compile with Java 11 and lets the plugin use recent tooling improvements like dependabot and the plugin bill of materials.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
