### PR TITLE
[JENKINS-72567] Fix StackOverflowError from CasC

### DIFF
--- a/src/main/java/hudson/plugins/blazemeter/BlazeMeterPerformanceBuilderDescriptor.java
+++ b/src/main/java/hudson/plugins/blazemeter/BlazeMeterPerformanceBuilderDescriptor.java
@@ -72,23 +72,16 @@ public class BlazeMeterPerformanceBuilderDescriptor extends BuildStepDescriptor<
     private String blazeMeterURL = Constants.A_BLAZEMETER_COM;
     private boolean isUnstableIfHasFails = false;
     private String name = "My BlazeMeter Account";
-    private static BlazeMeterPerformanceBuilderDescriptor descriptor;
-
-    public static void setDescriptor(BlazeMeterPerformanceBuilderDescriptor descriptor) {
-        BlazeMeterPerformanceBuilderDescriptor.descriptor = descriptor;
-    }
 
     public BlazeMeterPerformanceBuilderDescriptor() {
         super(PerformanceBuilder.class);
         this.load();
-        setDescriptor(this);
     }
 
     public BlazeMeterPerformanceBuilderDescriptor(String blazeMeterURL) {
         super(PerformanceBuilder.class);
         this.load();
         this.blazeMeterURL = blazeMeterURL;
-        setDescriptor(this);
     }
 
     public BlazeMeterPerformanceBuilderDescriptor(String blazeMeterURL, boolean isUnstableIfHasFails) {
@@ -96,11 +89,10 @@ public class BlazeMeterPerformanceBuilderDescriptor extends BuildStepDescriptor<
         this.load();
         this.blazeMeterURL = blazeMeterURL;
         this.isUnstableIfHasFails = isUnstableIfHasFails;
-        setDescriptor(this);
     }
 
     public static BlazeMeterPerformanceBuilderDescriptor getDescriptor() {
-        return BlazeMeterPerformanceBuilderDescriptor.descriptor;
+        return Jenkins.get().getDescriptorByType(BlazeMeterPerformanceBuilderDescriptor.class);
     }
 
     @Override
@@ -370,8 +362,7 @@ public class BlazeMeterPerformanceBuilderDescriptor extends BuildStepDescriptor<
         UserNotifier serverUserNotifier = new BzmServerNotifier();
         Logger logger = new BzmServerLogger();
         ProxyConfigurator.updateProxySettings(ProxyConfiguration.load(), false);
-        return new JenkinsBlazeMeterUtils(username, password,
-                BlazeMeterPerformanceBuilderDescriptor.descriptor.blazeMeterURL, serverUserNotifier, logger);
+        return new JenkinsBlazeMeterUtils(username, password, getDescriptor().blazeMeterURL, serverUserNotifier, logger);
     }
 
     public String getName() {


### PR DESCRIPTION
[JENKINS-72567](https://issues.jenkins.io/browse/JENKINS-72567)

Remove the cyclic reference of `BlazeMeterPerformanceBuilderDescriptor`

### Testing done

Tested import / export of a `jenkins.yaml`:

```yaml
unclassified:
  blazeMeterTest:
    blazeMeterURL: "https://a.blazemeter.example.com"
    isUnstableIfHasFails: "true"
    name: "My BlazeMeter"
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue